### PR TITLE
Vagrant improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 vendor/
 vendor-old/
+.vagrant

--- a/README.md
+++ b/README.md
@@ -29,15 +29,10 @@ Per installare il plugin è necessario copiare la directory `spid-wordpress` all
 
 ## Sviluppo
 
-Per agevolare lo sviluppo del plugin è stato creato un `Vagrantfile` per creare una VM sul proprio ambiente di sviluppo pronta per l'utilizzo del plugin.
-Per poter creare l'ambiente basta digitare nella directory del repository:
+Per agevolare lo sviluppo del plugin è stato creato un ambiente di development basato su [Vagrant](https://www.vagrantup.com/).
+Per poter creare l'ambiente basta digitare nella directory del repository: `vagrant up`
 
-   `vagrant up`
-
-Finito il processo di provisioning potete procedere con l'installazione di wordpress tramite il link:
-
-   `http://localhost:8080/wordpress`
-
+Finito il processo di provisioning potete accedere a WP tramite l'indirizzo: [http://localhost:8080](http://localhost:8080)
 
 
 ## Licenza

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,78 +1,23 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-# All Vagrant configuration is done below. The "2" in Vagrant.configure
-# configures the configuration version (we support older styles for
-# backwards compatibility). Please don't change it unless you know what
-# you're doing.
 Vagrant.configure("2") do |config|
-  # The most common configuration options are documented and commented below.
-  # For a complete reference, please see the online documentation at
-  # https://docs.vagrantup.com.
 
-  # Every Vagrant development environment requires a box. You can search for
-  # boxes at https://atlas.hashicorp.com/search.
+  ENV["LC_ALL"] = "en_US.UTF-8" # set locale for SSH agent
+
   config.vm.box = "bento/ubuntu-16.04"
-  # Disable automatic box update checking. If you disable this, then
-  # boxes will only be checked for updates when the user runs
-  # `vagrant box outdated`. This is not recommended.
-  # config.vm.box_check_update = false
+  config.vm.hostname = 'spid-wordpress'
 
-  # Create a forwarded port mapping which allows access to a specific port
-  # within the machine from a port on the host machine. In the example below,
-  # accessing "localhost:8080" will access port 80 on the guest machine.
-  # NOTE: This will enable public access to the opened port
-  config.vm.network "forwarded_port", guest: 80, host: 8080
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+  config.vm.synced_folder "./spid-wordpress", "/spid-wordpress"
 
-  # Create a forwarded port mapping which allows access to a specific port
-  # within the machine from a port on the host machine and only allow access
-  # via 127.0.0.1 to disable public access
-  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+  config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
 
-  # Create a private network, which allows host-only access to the machine
-  # using a specific IP.
-  # config.vm.network "private_network", ip: "192.168.33.10"
-
-  # Create a public network, which generally matched to bridged network.
-  # Bridged networks make the machine appear as another physical device on
-  # your network.
-  # config.vm.network "public_network"
-
-  # Share an additional folder to the guest VM. The first argument is
-  # the path on the host to the actual folder. The second argument is
-  # the path on the guest to mount the folder. And the optional third
-  # argument is a set of non-required options.
-  # config.vm.synced_folder "../data", "/vagrant_data"
-
-  # Provider-specific configuration so you can fine-tune various
-  # backing providers for Vagrant. These expose provider-specific options.
-  # Example for VirtualBox:
-  #
   config.vm.provider "virtualbox" do |vb|
-    # Display the VirtualBox GUI when booting the machine
-    # vb.gui = true
-
-    # Customize the amount of memory on the VM:
-    vb.memory = "1024"
+    vb.name = "spid-wordpress"
+    vb.customize [ "modifyvm", :id, "--uartmode1", "disconnected" ] # disable cloudimg-console.log
   end
-  #
-  # View the documentation for the provider you are using for more
-  # information on available options.
 
-  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
-  # such as FTP and Heroku are also available. See the documentation at
-  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
-  # config.push.define "atlas" do |push|
-  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
-  # end
-  config.ssh.username = 'vagrant'
-  config.ssh.password = 'vagrant'
-  config.ssh.insert_key = 'true'
+  config.vm.provision "shell", path: "./scripts/bootstrap.sh"
 
-  # Enable provisioning with a shell script. Additional provisioners such as
-  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
-  # documentation for more information about their specific syntax and use.
-  config.vm.provision "shell" do |s|
-         s.path = 'scripts/bootstrap.sh'  	
-  end
 end

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,36 +1,53 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
-apt-get update
+set -e
+
+TMP_DIR="$(mktemp -d)"
+SEED_FILE='/root/.provisioning_done'
+WP_URL="http://localhost:8080"
+DOCUMENT_ROOT="/var/www/html"
+
+trap 'rm -rf "$TMP_DIR"' EXIT INT QUIT TERM
+
+if [ -f $SEED_FILE ];
+then
+    printf "\nVM provisioning gia' completato.\n"
+    printf "Puoi accedere all'installazione di WP all'indirizzo: %s\n" "$WP_URL"
+    exit 0
+fi
+
+# Pre-requisites
 export DEBIAN_FRONTEND="noninteractive"
+apt-get update
+printf "mysql-server mysql-server/root_password password root" | debconf-set-selections
+printf "mysql-server mysql-server/root_password_again password root" | debconf-set-selections
 
-# Setup LAMP
-debconf-set-selections <<< "mysql-server mysql-server/root_password password root"
-debconf-set-selections <<< "mysql-server mysql-server/root_password_again password root"
+# Install LAMP stack
 apt-get install -y apache2 php mysql-server libapache2-mod-php php-mysql
 
-# Creo il DB
-mysql -u root -proot  -e "CREATE DATABASE IF NOT EXISTS wordpress"
-
-cd /var/www/html
-# Scarico ultima versione
-curl -O https://wordpress.org/latest.tar.gz
-
-# Estrai archivio
-tar xvfz latest.tar.gz
-
-
-
-# Imposta permessi
-chown -R www-data:www-data wordpress/
-
-# Installo il plugin
-cd /tmp
-git clone https://github.com/italia/spid-wordpress
-cp -R spid-wordpress/spid-wordpress /var/www/html/wordpress/wp-content/plugins
-chown -R www-data:www-data /var/www/html/wordpress/wp-content/plugins
-
-# Restart apache2
+# Remove default index.html & reload apache2 (required to load the new installed extensions)
+rm $DOCUMENT_ROOT/index.html
 service apache2 restart
 
-# Fine
-echo Fine.
+# Setup database
+mysql -u root -proot -e "CREATE DATABASE IF NOT EXISTS wordpress"
+
+# Download latest version of wordpress
+wget -O "$TMP_DIR/wordpress.tar.gz" https://wordpress.org/latest.tar.gz
+tar xvfz "$TMP_DIR/wordpress.tar.gz" --strip 1 -C $DOCUMENT_ROOT
+
+# Initialize wp-config.php with DB infos
+cp $DOCUMENT_ROOT/wp-config-sample.php $DOCUMENT_ROOT/wp-config.php
+chown www-data:www-data -R $DOCUMENT_ROOT
+sed -i "/DB_HOST/s/'[^']*'/'localhost'/2" $DOCUMENT_ROOT/wp-config.php
+sed -i "/DB_NAME/s/'[^']*'/'wordpress'/2" $DOCUMENT_ROOT/wp-config.php
+sed -i "/DB_USER/s/'[^']*'/'root'/2" $DOCUMENT_ROOT/wp-config.php
+sed -i "/DB_PASSWORD/s/'[^']*'/'root'/2" $DOCUMENT_ROOT/wp-config.php
+
+# Symlink spid-wordpress source code to the WP plugin directory
+ln -s /spid-wordpress $DOCUMENT_ROOT/wp-content/plugins
+
+# Provisioning completed
+touch $SEED_FILE
+printf "\nVM provisioning completato.\n"
+printf "Puoi accedere all'installazione di WP all'indirizzo: %s\n" "$WP_URL"


### PR DESCRIPTION
1. `VagrantFile` cleanup
    * removed useless comments & added minor improvements
    * disabled default export of `/vagrant`
    * add synced_folder for the plugin source code (see below)
    * add `host_ip` flag to `config.vm.network` (according to the Vagrant documentation everyone in the same network of the host was able to reach the exported guest port)
1. `scripts/bootstrap.sh`
    * now POSIX compliant
    * added logic to avoid the re-provisioning if the VM is already configured
    * moved WP location to [http://localhost:8080](http://localhost:8080)
    * added WP database initialization (this removes a step of the web-ui setup)
    * use the local source code checkout instead of re-downloading it from GitHub. This allows developers to make changes on their workstation and directly see the result in the browser
1. Add `.vagrant` to `.gitignore`